### PR TITLE
plus-star-to-infinity

### DIFF
--- a/PetitParser2/PP2Plus.class.st
+++ b/PetitParser2/PP2Plus.class.st
@@ -29,17 +29,14 @@ PP2Plus >> initializeFor: aNode [
 PP2Plus >> parseOn: aPP2Context [
 	| elements retval |
 	
-	(retval := child parseOn: aPP2Context) isPetit2Failure ifTrue: [
-		^ retval
-	].
+	(retval := child parseOn: aPP2Context) isPetit2Failure
+		ifTrue: [ ^ retval ].
 	elements := OrderedCollection with: retval.
-	
-	(node max - 1) timesRepeat: [
-	 	(retval := child parseOn: aPP2Context) isPetit2Failure ifTrue: [ 
-			^ elements 
-		].
+
+	[ (retval := child parseOn: aPP2Context) isPetit2Failure
+		ifTrue: [ ^ elements ].
 		elements addLast: retval 
-	].
+	] repeat.
 
 	^ elements
 ]

--- a/PetitParser2/PP2PlusRecognizer.class.st
+++ b/PetitParser2/PP2PlusRecognizer.class.st
@@ -8,15 +8,12 @@ Class {
 PP2PlusRecognizer >> parseOn: aPP2Context [
 	| retval |
 		
-	(retval := node child parseOn: aPP2Context) isPetit2Failure ifTrue: [
-		^ retval
-	].
+	(retval := node child parseOn: aPP2Context) isPetit2Failure
+		ifTrue: [ ^ retval ].
 
-	(node max - 1) timesRepeat: [
-	 	(retval := node child parseOn: aPP2Context) isPetit2Failure ifTrue: [ 
-			^ self 
-		].
-	].
+	[ (retval := node child parseOn: aPP2Context) isPetit2Failure
+		ifTrue: [ ^ self ].
+	] repeat.
 
 
 ]

--- a/PetitParser2/PP2RepeatingNode.class.st
+++ b/PetitParser2/PP2RepeatingNode.class.st
@@ -17,7 +17,7 @@ PP2RepeatingNode >> accept: aPP2Visitor [
 PP2RepeatingNode >> initialize [
 	super initialize.
 	min := 0.
-	max := SmallInteger maxVal.
+	max := Float infinity.
 ]
 
 { #category : #testing }

--- a/PetitParser2/PP2SpecializingVisitor.class.st
+++ b/PetitParser2/PP2SpecializingVisitor.class.st
@@ -101,7 +101,7 @@ PP2SpecializingVisitor >> isPlus: node [
 { #category : #testing }
 PP2SpecializingVisitor >> isPlusPredicateObject: node [ 
 	^ (node min = 1) and: [ 
-	  (node max = SmallInteger maxVal) and: [ 
+	  (node max = Float infinity) and: [ 
 	  node child isKindOf: PP2PredicateObjectNode 
 	]]
 ]
@@ -114,7 +114,7 @@ PP2SpecializingVisitor >> isStar: node [
 { #category : #testing }
 PP2SpecializingVisitor >> isStarPredicateObject: node [ 
 	^ (node min = 0) and: [ 
-	  (node max = SmallInteger maxVal) and: [ 
+	  (node max = Float infinity) and: [ 
 	  node child isKindOf: PP2PredicateObjectNode 
 	]]
 ]

--- a/PetitParser2/PP2Star.class.st
+++ b/PetitParser2/PP2Star.class.st
@@ -30,12 +30,10 @@ PP2Star >> parseOn: aPP2Context [
 	| elements retval |
 	elements := OrderedCollection new.
 	
-	node max timesRepeat: [
-		(retval := child parseOn: aPP2Context) isPetit2Failure ifTrue: [
-			^ elements
-		].
+	[ (retval := child parseOn: aPP2Context) isPetit2Failure
+		ifTrue: [ ^ elements ].
 		elements addLast: retval 
-	].
+	] repeat.
 	
 	^ elements
 ]


### PR DESCRIPTION
Make star and plus parse arbitrary many elements

Before, SmallInteger>>maxVal was used as upper bound in parsing star and plus.
This may fail if the input is sufficiently long, even earlier on 32 Bit.
Now we use 'inf := Float class>>inifinity' as uppber bound, as i < inf for each integer i.