### PR TITLE
new test method: testCurrentContext

### DIFF
--- a/PetitParser2-Tests/PP2NoopVisitorTest.class.st
+++ b/PetitParser2-Tests/PP2NoopVisitorTest.class.st
@@ -17,6 +17,16 @@ PP2NoopVisitorTest >> setUp [
 ]
 
 { #category : #tests }
+PP2NoopVisitorTest >> testCurrentContext [
+	parser := $a asPParser.
+	result := visitor visit: parser.
+	self assert: result currentContext class equals: PP2NoopContext.
+	self assert: result currentContext properties isNil.
+	self assert: result currentContext node isNil.
+	self assert: result currentContext propertiesCopy isNil
+]
+
+{ #category : #tests }
 PP2NoopVisitorTest >> testVisitCharacter [
 	parser := $a asPParser.
 	result := visitor visit: parser.


### PR DESCRIPTION
I submit this pull request to suggest a test method `PP2NoopVisitorTest >> testCurrentContext`.

We noticed that the method #currentContext is never executed by any of the tests in PP2NoopVisitorTest. 

Note that these suggestions are adapted from a test amplification tool called SmallAmp (https://github.com/mabdi/small-amp). SmallAmp executes existing tests, sees which parts of the class under test are not covered and then suggests improvements on the test methods.

I hope you will accept this pull request. It would illustrate that SmallAmp makes relevant suggestions.

Mehrdad Abdi.
