### PR TITLE
Fix the implementation of #isDelegate

### DIFF
--- a/PetitParser2/PP2DelegateNode.class.st
+++ b/PetitParser2/PP2DelegateNode.class.st
@@ -63,7 +63,7 @@ PP2DelegateNode >> isCacheForbidden [
 
 { #category : #testing }
 PP2DelegateNode >> isDelegate [
-	self class == PP2DelegateNode 
+	^ true
 ]
 
 { #category : #testing }

--- a/PetitParser2/PP2Node.class.st
+++ b/PetitParser2/PP2Node.class.st
@@ -442,6 +442,11 @@ PP2Node >> isDebugging [
 ]
 
 { #category : #testing }
+PP2Node >> isDelegate [
+	^ false
+]
+
+{ #category : #testing }
 PP2Node >> isEOI [
 	^ false
 ]


### PR DESCRIPTION
#isDelegate returns and does nothing. Now it return if a PP2Node is a Delegate.
It return true for any Delegate since we have #isJustDelegate to know if a node is and is only a Delegate.