### PR TITLE
Update PP2CompositeNodeTest.class.st

### DIFF
--- a/PetitParser2-Tests/PP2CompositeNodeTest.class.st
+++ b/PetitParser2-Tests/PP2CompositeNodeTest.class.st
@@ -53,13 +53,12 @@ PP2CompositeNodeTest >> parse: aString production: production to: expectedResult
 	ctx := self context.
 	resultContext := self parse: aString withParser: production withContext: ctx.
 	result := resultContext value.
-	
-	self
-		deny: resultContext isPetit2Failure
-		description: 'Unable to parse ' , aString printString.
-	
-	self assert: resultContext position equals: end.
-	aBoolean ifTrue: [ self assert: expectedResult equals: result ].
+	resultContext isPetit2Failure
+		ifTrue: [ self assert: expectedResult isPetit2Failure ]
+		ifFalse: [ self assert: resultContext position equals: end.
+			aBoolean
+				ifTrue: [ self assert: expectedResult equals: result ]
+	       ].
 	^ result
 ]
 


### PR DESCRIPTION
If parsing error occurs  when testing the expected result should be a PP2Failure