### PR TITLE
Fixing my bug which would cause infinite loop if code used

### DIFF
--- a/PetitParser2-Tests/PP2CompositeNodeTest.class.st
+++ b/PetitParser2-Tests/PP2CompositeNodeTest.class.st
@@ -71,7 +71,7 @@ PP2CompositeNodeTest >> fail: aString rule: aSymbol to: expectedResult end: expe
 PP2CompositeNodeTest >> fail: aString rule: aSymbol to: expectedResult end: expectedFailurePosition checkResult: aBoolean [ 
 	| production |
 	production := self parserInstanceFor: aSymbol.
-  ^ self fail: aString rule: aSymbol to: expectedResult end: expectedFailurePosition checkResult: aBoolean
+	^ self fail: aString production: production to: expectedResult end: expectedFailurePosition checkResult: aBoolean
 ]
 
 { #category : #parsing }


### PR DESCRIPTION
Somewhere during the copy&paste I made an error which causes infinite loop when using fail for testing.  Funny is that my patch was originally correct and it did not occur to me that I have made an error when creating the PR.