### PR TITLE
Fix PP2WaterNodeTest.class.st for newer Pharo

### DIFF
--- a/PetitParser2-Tests/PP2WaterNodeTest.class.st
+++ b/PetitParser2-Tests/PP2WaterNodeTest.class.st
@@ -12,7 +12,7 @@ PP2WaterNodeTest >> testBoundaryElements [
 	water := PP2WaterNode new.
 	boundary := $a asPParser.
 	
-	water boundaryElements: boundary asOrderedCollection.
+	water boundaryElements: (OrderedCollection with: boundary).
 	
 	self assert: water boundary isKindOf: PP2ChoiceNode.
 	self assert: water boundary firstChild isKindOf: PP2AndNode.


### PR DESCRIPTION
Object no longer understands asOrderedCollection (https://github.com/pharo-project/pharo/commit/86ed9d408a386d1c95d8d911b50b9577000c268d)